### PR TITLE
icecream: Fix docbook2x dependency case

### DIFF
--- a/Formula/icecream.rb
+++ b/Formula/icecream.rb
@@ -19,7 +19,7 @@ class Icecream < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "lzo"
-  depends_on "docbook2X" => [:optional, :build]
+  depends_on "docbook2x" => [:optional, :build]
 
   def install
     args = %W[


### PR DESCRIPTION
Something I stumbled upon during debugging [Homebrew/formulae.brew.sh](https://github.com/Homebrew/formulae.brew.sh). Maybe this would even fail on a case-sensitive file system?

I wonder if it would make sense to check something like this with `brew audit`.